### PR TITLE
Update APIs for Atom 1.0

### DIFF
--- a/lib/tabularize-view.coffee
+++ b/lib/tabularize-view.coffee
@@ -46,7 +46,7 @@ class TabularizeView extends View
 
   confirm: ->
     regex = @miniEditor.getText()
-    editor = atom.workspace.getActiveEditor()
+    editor = atom.workspace.getActiveTextEditor()
 
     @close()
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "main": "./lib/tabularize-view",
   "version": "0.2.3",
   "description": "Atom package for text alignment",
-  "activationEvents": [
-    "tabularize:toggle"
-  ],
+  "activationCommands": {
+    "atom-text-editor": ["tabularize:toggle"]
+  },
   "repository": "https://github.com/pcasaretto/atom-tabularize",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This PR removes two deprecations that will be removed from Atom on June 1.
